### PR TITLE
Fix an error caused by Amazon changing a nested array name

### DIFF
--- a/src/sections/products/codec.ts
+++ b/src/sections/products/codec.ts
@@ -91,7 +91,7 @@ const FeeDetail: Codec<FeeDetailInterface> = Codec.interface({
   FinalFee: MoneyType,
   IncludedFeeDetailList: optional(
     ensureArray(
-      'IncludedFeeDetail',
+      'FeeDetail',
       lazy(() => FeeDetail),
     ),
   ),

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "tsconfigs/nodejs-module",
   "compilerOptions": {
+    "lib": ["dom"],
     "outDir": "lib",
     "target": "es2019"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "tsconfigs/nodejs-module",
   "compilerOptions": {
-    "lib": ["dom"],
     "outDir": "lib",
     "target": "es2019"
   },


### PR DESCRIPTION
Steps to repro:

```typescript
const mwsProducts = new Products(mwsHttp);

(async function () {
  let fees;
  try {
    fees = await mwsProducts.getMyFeesEstimate({
      FeesEstimateRequestList: [
        {
          IdType: 'ASIN',
          IdValue: 'SAMPLE_ASIN',
          Identifier: `${Date.now()}`,
          IsAmazonFulfilled: true,
          MarketplaceId: amazonMarketplaces.US.id,
          PriceToEstimateFees: {
            ListingPrice: {Amount: 100.00, CurrencyCode: 'USD'},
          },
        },
      ],
    });
  } catch (e) {
    console.error(e);
  }
  console.log(JSON.stringify(fees));
})();
```

Currently, this gives the following rather long error:
```
Problem with the value of property "IncludedFeeDetailList": One of the following problems occured: (0) Problem with value at index 0: Expected an object, but received undefined, (1) Expected an undefined, but received an object with value {"FeeDetail":[{"FeeAmount":{"Amount":0,"CurrencyCode":"USD"},"FinalFee":{"Amount":0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAWeightHandling"},{"FeeAmount":{"Amount":5.8,"CurrencyCode":"USD"},"FinalFee":{"Amount":5.8,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAPickAndPack"},{"FeeAmount":{"Amount":0,"CurrencyCode":"USD"},"FinalFee":{"Amount":0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAOrderHandling"}]}, (1) Expected an undefined, but received an object with value {"TimeOfFeesEstimation":"DATE","TotalFeesEstimate":{"Amount":10.0,"CurrencyCode":"USD"},"FeeDetailList":{"FeeDetail":[{"FeeAmount":{"Amount":5.0,"CurrencyCode":"USD"},"FinalFee":{"Amount":5.0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"ReferralFee"},{"FeeAmount":{"Amount":0,"CurrencyCode":"USD"},"FinalFee":{"Amount":0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"VariableClosingFee"},{"FeeAmount":{"Amount":0,"CurrencyCode":"USD"},"FinalFee":{"Amount":0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"PerItemFee"},{"FeeAmount":{"Amount":5.0,"CurrencyCode":"USD"},"FinalFee":{"Amount":5.0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAFees","IncludedFeeDetailList":{"FeeDetail":[{"FeeAmount":{"Amount":0,"CurrencyCode":"USD"},"FinalFee":{"Amount":0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAWeightHandling"},{"FeeAmount":{"Amount":5.0,"CurrencyCode":"USD"},"FinalFee":{"Amount":5.0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAPickAndPack"},{"FeeAmount":{"Amount":0,"CurrencyCode":"USD"},"FinalFee":{"Amount":0,"CurrencyCode":"USD"},"FeePromotion":{"Amount":0,"CurrencyCode":"USD"},"FeeType":"FBAOrderHandling"}]}}]}}
    at Object.Left (/MY_PATH/node_modules/@scaleleap/amazon-mws-api-sdk/src/sections/products/products.ts:93:15)
    at Left.caseOf (/MY_PATH/node_modules/purify-ts/Either.js:269:58)
    at Products.getMyFeesEstimate (/MY_PATH/node_modules/@scaleleap/amazon-mws-api-sdk/src/sections/products/products.ts:90:55)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Digging in, it looks like Amazon renamed the nested `IncludedFeeDetailList` array's key to be just `FeeDetail` instead of `IncludedFeeDetail`.

<hr>

I also fixed a compile error in `tsconfig.build.json` caused by the emscripten dependency depending on the Typescript `dom` library. I don't mind splitting them out, but this was what it took to get it to work locally. ;)