### PR TITLE
fix: adds repo description and keywords and set up sync

### DIFF
--- a/.github/workflows/sync-node-meta.yml
+++ b/.github/workflows/sync-node-meta.yml
@@ -1,0 +1,26 @@
+name: Sync package.json with repository info
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Sync repo with package.json
+        uses: jaid/action-sync-node-meta@v1.4.0
+        with:
+          direction: overwrite-github
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          syncHomepage: "false"
+          commitMessagePrefix: "chore:"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 📦 @scaleleap/amazon-mws-api-sdk
 ===================================
 
-A fully typed TypeScript SDK library for Amazon MWS API
+A fully typed TypeScript and Node.js SDK library for Amazon MWS API
 
 ## Download & Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scaleleap/amazon-mws-api-sdk",
-  "description": "",
+  "description": "📦A fully typed TypeScript and Node.js SDK library for Amazon MWS API",
   "license": "MIT",
   "author": {
     "name": "Roman Filippov",
@@ -67,7 +67,20 @@
     "tsconfigs": "4.0.2",
     "typescript": "3.9.7"
   },
-  "keywords": [],
+  "keywords": [
+    "amazon marketplace web service",
+    "amazon mws",
+    "amazon mws api",
+    "amazon mws libraries",
+    "amazon mws sdk",
+    "fba",
+    "fbm",
+    "mws",
+    "mws api",
+    "mws sdk",
+    "nodejs",
+    "typescript"
+  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Adds missing package description and keywords to help the package being
found in the NPM results. Sets up automatic syncing of the package info
with GitHub repo details.

This should help package discoverability that was brought up in #155 