### PR TITLE
Change Name on ShippingAddress to be optional

### DIFF
--- a/src/sections/orders.ts
+++ b/src/sections/orders.ts
@@ -97,7 +97,7 @@ const conditionSubtype: Codec<ConditionSubtype> = oneOf(
 )
 
 const Address = Codec.interface({
-  Name: string,
+  Name: optional(string),
   AddressLine1: optional(string),
   AddressLine2: optional(string),
   AddressLine3: optional(string),


### PR DESCRIPTION
I hit this error while pulling my own orders and an order came back without a name. Confirmed it works after fixing this.