### PR TITLE
fix: add missing adjustment types

### DIFF
--- a/src/sections/finances/codec.ts
+++ b/src/sections/finances/codec.ts
@@ -338,6 +338,7 @@ export enum AdjustmentTypeEnum {
   PostageBilling = 'PostageBilling',
   PostageBillingTransactionFee = 'PostageBilling_TransactionFee',
   PostageBillingInsurance = 'PostageBilling_Insurance',
+  PostageBillingDeliveryConfirmation = 'PostageBilling_DeliveryConfirmation',
   PostageRefund = 'PostageRefund',
   LostOrDamagedReimbursement = 'LostOrDamagedReimbursement',
   CanceledButPickedUpReimbursement = 'CanceledButPickedUpReimbursement',

--- a/src/sections/finances/codec.ts
+++ b/src/sections/finances/codec.ts
@@ -339,6 +339,7 @@ export enum AdjustmentTypeEnum {
   PostageBillingTransactionFee = 'PostageBilling_TransactionFee',
   PostageBillingInsurance = 'PostageBilling_Insurance',
   PostageBillingDeliveryConfirmation = 'PostageBilling_DeliveryConfirmation',
+  PostageBillingPostage = 'PostageBilling_Postage',
   PostageRefund = 'PostageRefund',
   LostOrDamagedReimbursement = 'LostOrDamagedReimbursement',
   CanceledButPickedUpReimbursement = 'CanceledButPickedUpReimbursement',

--- a/src/sections/finances/codec.ts
+++ b/src/sections/finances/codec.ts
@@ -337,6 +337,7 @@ export enum AdjustmentTypeEnum {
   ReserveEvent = 'ReserveEvent',
   PostageBilling = 'PostageBilling',
   PostageBillingTransactionFee = 'PostageBilling_TransactionFee',
+  PostageBillingInsurance = 'PostageBilling_Insurance',
   PostageRefund = 'PostageRefund',
   LostOrDamagedReimbursement = 'LostOrDamagedReimbursement',
   CanceledButPickedUpReimbursement = 'CanceledButPickedUpReimbursement',

--- a/src/sections/finances/codec.ts
+++ b/src/sections/finances/codec.ts
@@ -344,6 +344,7 @@ export enum AdjustmentTypeEnum {
   LostOrDamagedReimbursement = 'LostOrDamagedReimbursement',
   CanceledButPickedUpReimbursement = 'CanceledButPickedUpReimbursement',
   ReimbursementClawback = 'ReimbursementClawback',
+  ReversalReimbursement = 'REVERSAL_REIMBURSEMENT',
   SellerRewards = 'SellerRewards',
 }
 

--- a/src/sections/finances/codec.ts
+++ b/src/sections/finances/codec.ts
@@ -336,6 +336,7 @@ export enum AdjustmentTypeEnum {
   FBAInventoryReimbursement = 'FBAInventoryReimbursement',
   ReserveEvent = 'ReserveEvent',
   PostageBilling = 'PostageBilling',
+  PostageBillingTransactionFee = 'PostageBilling_TransactionFee',
   PostageRefund = 'PostageRefund',
   LostOrDamagedReimbursement = 'LostOrDamagedReimbursement',
   CanceledButPickedUpReimbursement = 'CanceledButPickedUpReimbursement',


### PR DESCRIPTION
This PR fixes issues related to the following error:

`ParsingError: Problem with the value of property "ListFinancialEventsResponse": Problem with the value of property "ListFinancialEventsResult": Problem with the value of property "FinancialEvents": Problem with the value of property "AdjustmentEventList": One of the following problems occured: (0) Problem with the value at index 0: Problem with the value of property "AdjustmentType": One of the following problems occured: (0) Expected an enum member, but received a string with value "REVERSAL_REIMBURSEMENT", (1) Expected an undefined, but received a string with value "REVERSAL_REIMBURSEMENT", (1) Expected an undefined, but received an object with value {{ redacted }}`

Closes #250 