### PR TITLE
fix(orders): parse `ShippingAddress` as string

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -337,7 +337,19 @@ export const parseResponse = <T>(
           parseTrueNumberOnly: true,
           tagValueProcessor: (value) => decode(value),
           // force to be parsed as string
-          stopNodes: ['Phone'],
+          stopNodes: [
+            'Name',
+            'AddressLine1',
+            'AddressLine2',
+            'AddressLine3',
+            'City',
+            'Municipality',
+            'StateOrRegion',
+            'PostalCode',
+            'CountryCode',
+            'Phone',
+            'AddressType',
+          ],
         },
         true,
       )

--- a/test/unit/__fixtures__/orders_list_orders.xml
+++ b/test/unit/__fixtures__/orders_list_orders.xml
@@ -154,6 +154,69 @@
               <PromiseResponseDueDate>2017-08-31T23:58:44Z</PromiseResponseDueDate>
               <IsEstimatedShipDateSet>true</IsEstimatedShipDateSet>
           </Order>
+          <Order>
+              <AmazonOrderId>058-1233752-8214740</AmazonOrderId>
+              <PurchaseDate>2017-02-05T00%3A06%3A07.000Z</PurchaseDate>
+              <LastUpdateDate>2017-02-07T12%3A43%3A16.000Z</LastUpdateDate>
+              <OrderStatus>Unshipped</OrderStatus>
+              <FulfillmentChannel>MFN</FulfillmentChannel>
+              <ShipServiceLevel>Std JP Kanto8</ShipServiceLevel>
+              <ShippingAddress>
+                  <Name>Jane Smith</Name>
+                  <AddressLine1>22</AddressLine1>
+                  <AddressLine2>kebab st</AddressLine2>
+                  <AddressLine3>321321321</AddressLine3>
+                  <City>Tokyo</City>
+                  <PostalCode>00148</PostalCode>
+                  <Phone>05 55 555555</Phone>
+                  <CountryCode>IT</CountryCode>
+              </ShippingAddress>
+              <OrderTotal>
+                  <CurrencyCode>JPY</CurrencyCode>
+                  <Amount>1507.00</Amount>
+              </OrderTotal>
+              <NumberOfItemsShipped>0</NumberOfItemsShipped>
+              <NumberOfItemsUnshipped>1</NumberOfItemsUnshipped>
+              <PaymentExecutionDetail>
+                  <PaymentExecutionDetailItem>
+                      <Payment>
+                          <Amount>10.00</Amount>
+                          <CurrencyCode>JPY</CurrencyCode>
+                      </Payment>
+                      <PaymentMethod>PointsAccount</PaymentMethod>
+                  </PaymentExecutionDetailItem>
+                  <PaymentExecutionDetailItem>
+                      <Payment>
+                          <Amount>317.00</Amount>
+                          <CurrencyCode>JPY</CurrencyCode>
+                      </Payment>
+                      <PaymentMethod>GC</PaymentMethod>
+                  </PaymentExecutionDetailItem>
+                  <PaymentExecutionDetailItem>
+                      <Payment>
+                          <Amount>1180.00</Amount>
+                          <CurrencyCode>JPY</CurrencyCode>
+                      </Payment>
+                      <PaymentMethod>COD</PaymentMethod>
+                  </PaymentExecutionDetailItem>
+              </PaymentExecutionDetail>
+              <PaymentMethod>COD</PaymentMethod>
+              <PaymentMethodDetails>
+                  <PaymentMethodDetail>COD</PaymentMethodDetail>
+              </PaymentMethodDetails>
+              <MarketplaceId>A1VC38T7YXB528</MarketplaceId>
+              <BuyerEmail>5vlhEXAMPLEh9h5@marketplace.amazon.co.jp</BuyerEmail>
+              <BuyerName>Jane Smith</BuyerName>
+              <ShipmentServiceLevelCategory>Standard </ShipmentServiceLevelCategory>
+              <OrderType>SourcingOnDemandOrder</OrderType>
+              <IsBusinessOrder>false</IsBusinessOrder>
+              <IsPrime>false</IsPrime>
+              <IsPremiumOrder>false</IsPremiumOrder>
+              <IsGlobalExpressEnabled>false</IsGlobalExpressEnabled>
+              <PromiseResponseDueDate>2017-08-31T23:58:44Z</PromiseResponseDueDate>
+              <IsEstimatedShipDateSet>true</IsEstimatedShipDateSet>
+          </Order>
+          
       </Orders>
   </ListOrdersResult>
   <ResponseMetadata>

--- a/test/unit/__snapshots__/orders.test.ts.snap
+++ b/test/unit/__snapshots__/orders.test.ts.snap
@@ -307,6 +307,68 @@ Array [
           "PostalCode": "107-0053",
         },
       },
+      Object {
+        "AmazonOrderId": "058-1233752-8214740",
+        "BuyerEmail": "5vlhEXAMPLEh9h5@marketplace.amazon.co.jp",
+        "BuyerName": "Jane Smith",
+        "FulfillmentChannel": "MFN",
+        "IsBusinessOrder": false,
+        "IsEstimatedShipDateSet": true,
+        "IsGlobalExpressEnabled": false,
+        "IsPremiumOrder": false,
+        "IsPrime": false,
+        "LastUpdateDate": 2017-02-07T12:43:16.000Z,
+        "MarketplaceId": "A1VC38T7YXB528",
+        "NumberOfItemsShipped": 0,
+        "NumberOfItemsUnshipped": 1,
+        "OrderStatus": "Unshipped",
+        "OrderTotal": Object {
+          "Amount": 1507,
+          "CurrencyCode": "JPY",
+        },
+        "OrderType": "SourcingOnDemandOrder",
+        "PaymentExecutionDetail": Array [
+          Object {
+            "Payment": Object {
+              "Amount": 10,
+              "CurrencyCode": "JPY",
+            },
+            "PaymentMethod": "PointsAccount",
+          },
+          Object {
+            "Payment": Object {
+              "Amount": 317,
+              "CurrencyCode": "JPY",
+            },
+            "PaymentMethod": "GC",
+          },
+          Object {
+            "Payment": Object {
+              "Amount": 1180,
+              "CurrencyCode": "JPY",
+            },
+            "PaymentMethod": "COD",
+          },
+        ],
+        "PaymentMethod": "COD",
+        "PaymentMethodDetails": Array [
+          "COD",
+        ],
+        "PromiseResponseDueDate": 2017-08-31T23:58:44.000Z,
+        "PurchaseDate": 2017-02-05T00:06:07.000Z,
+        "ShipServiceLevel": "Std JP Kanto8",
+        "ShipmentServiceLevelCategory": "Standard",
+        "ShippingAddress": Object {
+          "AddressLine1": "22",
+          "AddressLine2": "kebab st",
+          "AddressLine3": "321321321",
+          "City": "Tokyo",
+          "CountryCode": "IT",
+          "Name": "Jane Smith",
+          "Phone": "05 55 555555",
+          "PostalCode": "00148",
+        },
+      },
     ],
   },
   Object {


### PR DESCRIPTION
part2 or https://github.com/ScaleLeap/amazon-mws-api-sdk/issues/365

All properties in `ShippingAddress` are filled by customers and should be strings

https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_Datatypes.html#Address