### PR TITLE
fix(orders): `BuyerName` as string

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -338,6 +338,8 @@ export const parseResponse = <T>(
           tagValueProcessor: (value) => decode(value),
           // force to be parsed as string
           stopNodes: [
+            'BuyerName',
+            // ? ShippingAddress fields
             'Name',
             'AddressLine1',
             'AddressLine2',

--- a/test/unit/__fixtures__/orders_list_orders.xml
+++ b/test/unit/__fixtures__/orders_list_orders.xml
@@ -206,7 +206,7 @@
               </PaymentMethodDetails>
               <MarketplaceId>A1VC38T7YXB528</MarketplaceId>
               <BuyerEmail>5vlhEXAMPLEh9h5@marketplace.amazon.co.jp</BuyerEmail>
-              <BuyerName>Jane Smith</BuyerName>
+              <BuyerName>321321321</BuyerName>
               <ShipmentServiceLevelCategory>Standard </ShipmentServiceLevelCategory>
               <OrderType>SourcingOnDemandOrder</OrderType>
               <IsBusinessOrder>false</IsBusinessOrder>

--- a/test/unit/__snapshots__/orders.test.ts.snap
+++ b/test/unit/__snapshots__/orders.test.ts.snap
@@ -310,7 +310,7 @@ Array [
       Object {
         "AmazonOrderId": "058-1233752-8214740",
         "BuyerEmail": "5vlhEXAMPLEh9h5@marketplace.amazon.co.jp",
-        "BuyerName": "Jane Smith",
+        "BuyerName": "321321321",
         "FulfillmentChannel": "MFN",
         "IsBusinessOrder": false,
         "IsEstimatedShipDateSet": true,


### PR DESCRIPTION
part 3
also `BuyerName` is a users filled field
```js
ParsingError: Problem with the value of property "ListOrdersByNextTokenResponse": Problem with the value of property "ListOrdersByNextTokenResult": Problem with the value of property 
"Orders": Problem with the value at index 85: 
Problem with the value of property `BuyerName` One of the following problems occured: (0) 
Expected a string, but received a number with 
value 33333333, (1) 
Expected an undefined, but received a number with value 33333333
```