### PR TITLE
fix(offer_count): type obj to array

### DIFF
--- a/src/sections/products/codec.ts
+++ b/src/sections/products/codec.ts
@@ -323,13 +323,16 @@ export const GetLowestOfferListingsForASINResponse = Codec.interface({
 const OfferCountType = Codec.interface({
   OfferCount: oneOf([
     number,
-    Codec.interface({
-      text: number,
-      attr: Codec.interface({
-        condition: optional(string),
-        fulfillmentChannel: optional(string),
+    ensureArray(
+      'OfferCount',
+      Codec.interface({
+        text: number,
+        attr: Codec.interface({
+          condition: optional(string),
+          fulfillmentChannel: optional(string),
+        }),
       }),
-    }),
+    ),
   ]),
 })
 


### PR DESCRIPTION
Care,
I dont know that `ensureArray` so before merging check if its coherent with the error

```js
ParsingError: Problem with the value of property `GetLowestPricedOffersForASINResponse`: 
Problem with the value of property `GetLowestPricedOffersForASINResult`: 
Problem with the value of property `Summary`: 
Problem with the value of property `NumberOfOffers`: 
One of the following problems occured: (0) 
Problem with the value of property "OfferCount": 
One of the following problems occured: (0) 
```

```js
Expected a number, but received an array with value 
[{
  "text":58,
  "attr":{"condition":"used","fulfillmentChannel":"Merchant"}
},
{
  "text":1,
  "attr":{"condition":"new","fulfillmentChannel":"Amazon"}
},
{
  "text":6,
  "attr":{"condition":"new","fulfillmentChannel":"Merchant"}
}], 
```

```js
(1) Expected an object, but received an array with value 
[{...}], 
```

```js
(1) Expected an undefined, but received an object with value {"OfferCount":[{"text":58,"attr":{"condition":"used","fulfillmentChannel":"Merchant"}},{"text":1,"attr":{"condition":"new","fulfillmentChannel":"Amazon"}},{"text":6,"attr":{"condition":"new","fulfillmentChannel":"Merchant"}}]
```